### PR TITLE
Bug/cpu not taking turn

### DIFF
--- a/game.js
+++ b/game.js
@@ -66,7 +66,7 @@ class Game {
   enemyTurn() {
     const availableSpots = this.board.flat().filter((num) => num > 0)
     const enemyPick = availableSpots[Math.floor(Math.random() * availableSpots.length)]
-    if (enemyPick <= 3) {
+    if (enemyPick <= 2) {
       this.takeTurn(0, enemyPick)
     } else if (enemyPick >= 6) {
       this.takeTurn(2, enemyPick)

--- a/game.js
+++ b/game.js
@@ -48,7 +48,7 @@ class Game {
       return this.decideWinner()
     }
 
-    if (this.board.flat().filter((num) => num > 0).length === 0) {
+    if (this.board.flat().filter((num) => num >= 0).length === 0) {
       return 0
     }
   }

--- a/main.js
+++ b/main.js
@@ -69,6 +69,8 @@ const restartGame = () => {
 const resetBoard = () => {
   currentGame.resetGame()
   updateBoard()
+  winnerDeclared = false
+  gameOutcome.classList.add('hidden')
   cpuFirstBtn.classList.remove('collapsed')
 }
 
@@ -192,6 +194,7 @@ const toggleLightDarkMode = () => {
 
 const declareWinner = () => {
   if (currentGame.checkBoard() === 0) {
+    console.log(currentGame.board)
     gameOutcome.classList.remove('hidden')
     gameOutcome.innerText = "Draw"
     winnerDeclared = true
@@ -258,9 +261,6 @@ cpuFirstBtn.addEventListener('click', cpuGoesFirst)
 gameBoard.addEventListener('click', function(event) {
   if (winnerDeclared) {
     resetBoard()
-    winnerDeclared = false
-    gameOutcome.classList.add('hidden')
-    cpuFirstBtn.classList.remove('collapsed')
   } else if (event.target.classList[0] === 'board-section') {
     takeTurn(boxOptions[event.target.classList[1]], boxOptions[event.target.classList[2]])
     cpuFirstBtn.classList.add('collapsed')

--- a/main.js
+++ b/main.js
@@ -261,7 +261,7 @@ cpuFirstBtn.addEventListener('click', cpuGoesFirst)
 gameBoard.addEventListener('click', function(event) {
   if (winnerDeclared) {
     resetBoard()
-  } else if (event.target.classList[0] === 'board-section') {
+  } else if (event.target.classList[0] === 'board-section' && currentGame.board.flat()[boxOptions[event.target.classList[2]]] >= 0) {
     takeTurn(boxOptions[event.target.classList[1]], boxOptions[event.target.classList[2]])
     cpuFirstBtn.classList.add('collapsed')
   }


### PR DESCRIPTION
# Pull Request ⇧

Fix several bugs: 
- CPU was not taking a turn occasionally if the chosen spot was '3' on the board.
- Message declaring the outcome would not disappear after hitting the reset button.
- Draw was declared too early if the first spot on the board was still not claimed.
- If the player clicked an already occupied space, a random piece would be placed on the board occasionally. 